### PR TITLE
Don't specify an explicit clusterIP for peertube redis

### DIFF
--- a/peertube/helmrelease-redis.yaml
+++ b/peertube/helmrelease-redis.yaml
@@ -559,7 +559,7 @@ spec:
         internalTrafficPolicy: Cluster
         ## @param master.service.clusterIP Redis&reg; master service Cluster IP
         ##
-        clusterIP: "10.43.0.7"
+        clusterIP: ""
         ## @param master.service.loadBalancerIP Redis&reg; master service Load Balancer IP
         ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
         ##


### PR DESCRIPTION
Signed-off-by: David Young <davidy@funkypenguin.co.nz>