### PR TITLE
Relax rate limit on static path for js, html, css content

### DIFF
--- a/mediafusion/ingressroute-mediafusion.yaml
+++ b/mediafusion/ingressroute-mediafusion.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: mediafusion
 spec:
   routes:
-    - match: Host(`mediafusion.${dns_domain}`) && (PathPrefix(`/streaming_provider`) || PathPrefix(`/poster`) || PathPrefix(`/configure`))
+    - match: Host(`mediafusion.${dns_domain}`) && (PathPrefix(`/streaming_provider`) || PathPrefix(`/poster`) || PathPrefix(`/configure`)) || PathPrefix(`/static`))
       kind: Rule
       services:
         - name: mediafusion


### PR DESCRIPTION
Users getting rate limit on required JS script when they initially open the home page and then open the configuration page, this will raise error when they tried to set up the add-on. 

![image](https://github.com/user-attachments/assets/5872ed8b-ed4d-41aa-ab64-4d3594a843f4)
